### PR TITLE
Update d15s01.rpy

### DIFF
--- a/french/code/d15/d15s01.rpy
+++ b/french/code/d15/d15s01.rpy
@@ -1838,7 +1838,7 @@ translate french d15s01_end_cbcf6bb4:
 translate french d15s01_end_cfc6d65b:
 
     # mc "Well, it was fun while it lasted."
-    mc "Eh bien, c'était amusant le temps que ça à durait."
+    mc "Eh bien, c'était amusant le temps que ça a duré."
 
 # game/code/d15/d15s01.rpy:1351
 translate french d15s01_end_7ea95347:


### PR DESCRIPTION
Minor correction "à" should only used in french if the "a" cannot be replaced by an equivalent of the verb "avoir" this is not the case here. "durait" is incorrectly conjugated here "durait" is conjugated in the past tense, hence the “a” in front of it must therefore be written “duré”